### PR TITLE
Correct GraphQLRequest signature

### DIFF
--- a/source/network.md
+++ b/source/network.md
@@ -223,9 +223,9 @@ This is the interface that an object should implement so that it can be used by 
 
 Represents a request passed to the network interface. Has the following properties:
 
-- `query: string` The query to send to the server.
+- `query: Object` AST of the query to send to the server. You can get stringify this value by using `print` function from `graphql-tag/printer` package.
 - `variables: Object` The variables to send with the query.
-- `debugName: string` An optional parameter that will be included in error messages about this query.
+- `operationName: string` An optional parameter that will be included in error messages about this query.
 
 <h3 id="GraphQLResult"><i>interface</i> GraphQLResult</h3>
 


### PR DESCRIPTION
Noticed that while trying to implement custom network interface. `GraphQLRequest` documentation incorrectly specifies 2 fields:
- `query` field will actually contain AST, not query.
- There is no `debugName`, there is only `operationName`

[Same type definition in apollo-client](https://github.com/apollostack/apollo-client/blob/master/src/transport/networkInterface.ts#L25)