### PR TITLE
Imperative read and write docs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/meteor/hexo-theme-meteor.git
 [submodule "code"]
 	path = code
-	url = https://github.com/apollostack/apollo-client.git
+	url = https://github.com/apollographql/apollo-client.git

--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,7 @@ sidebar_categories:
     - index
     - apollo-client-api
   'Technical Documentation':
+    - data-control
     - network
     - devtools
     - how-it-works

--- a/_config.yml
+++ b/_config.yml
@@ -18,8 +18,8 @@ sidebar_categories:
     - index
     - apollo-client-api
   'Technical Documentation':
-    - data-control
     - network
+    - read-and-write
     - devtools
     - how-it-works
   Integrations:

--- a/circle.yml
+++ b/circle.yml
@@ -12,8 +12,6 @@ dependencies:
   override:
     - npm install -g hexo-cli
     - npm install
-    - cd code; npm install
-
 
 test:
   override:

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "hexo-s3-deploy": "^1.2.1"
   },
   "scripts": {
+    "postinstall": "cd code && npm install && npm uninstall typescript && npm install typescript@2.1.6",
     "build": "cd code; typedoc --json ../docs.json",
     "prestart": "npm run build",
     "start": "hexo serve",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "hexo-renderer-less": "^0.2.0",
     "hexo-renderer-marked": "^0.2.4",
     "hexo-server": "^0.1.2",
-    "hexo-typescript-api-box": "^0.8.0",
+    "hexo-typescript-api-box": "apollographql/hexo-typescript-api-box#4539552c303c4482943424abec44b2864b8f634a",
     "typedoc": "^0.5.7"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
     "hexo-generator-index": "^0.1.2",
     "hexo-generator-tag": "^0.1.1",
     "hexo-renderer-ejs": "^0.1.0",
-    "hexo-renderer-marked": "^0.2.4",
     "hexo-renderer-less": "^0.2.0",
+    "hexo-renderer-marked": "^0.2.4",
     "hexo-server": "^0.1.2",
     "hexo-typescript-api-box": "^0.8.0",
-    "typedoc": "^0.5.0"
+    "typedoc": "^0.5.7"
   },
   "devDependencies": {
     "hexo-s3-deploy": "^1.2.1"

--- a/source/apollo-client-api.md
+++ b/source/apollo-client-api.md
@@ -12,6 +12,10 @@ The `ApolloClient` class is the core API for Apollo, and the one you'll need to 
 {% tsapibox ApolloClient.watchQuery %}
 {% tsapibox ApolloClient.query %}
 {% tsapibox ApolloClient.mutate %}
+{% tsapibox ApolloClient.readQuery %}
+{% tsapibox ApolloClient.readFragment %}
+{% tsapibox ApolloClient.writeQuery %}
+{% tsapibox ApolloClient.writeFragment %}
 {% tsapibox ApolloClient.reducer %}
 {% tsapibox ApolloClient.middleware %}
 {% tsapibox ApolloClient.initStore %}

--- a/source/apollo-client-api.md
+++ b/source/apollo-client-api.md
@@ -37,11 +37,21 @@ The `ApolloClient` class is the core API for Apollo, and the one you'll need to 
 {% tsapibox ObservableQuery.stopPolling %}
 
 <h2 id="ApolloError">ApolloError</h2>
+
 {% tsapibox ApolloError.constructor %}
 {% tsapibox ApolloError.message %}
 {% tsapibox ApolloError.graphQLErrors %}
 {% tsapibox ApolloError.networkError %}
 {% tsapibox ApolloError.extraInfo %}
+
+<h2 id="DataProxy">DataProxy</h2>
+
+An interface to the normalized data in your store. `ApolloClient` implements this interface and so do various other objects you may receive when updating the store. A `DataProxy` is used in the `update` function on `client.mutate` to give you a window into your normalized data.
+
+{% tsapibox DataProxy.readQuery %}
+{% tsapibox DataProxy.readFragment %}
+{% tsapibox DataProxy.writeQuery %}
+{% tsapibox DataProxy.writeFragment %}
 
 <h2 id="utilities">Utilities</h2>
 

--- a/source/apollo-client-api.md
+++ b/source/apollo-client-api.md
@@ -48,6 +48,8 @@ The `ApolloClient` class is the core API for Apollo, and the one you'll need to 
 
 An interface to the normalized data in your store. `ApolloClient` implements this interface and so do various other objects you may receive when updating the store. A `DataProxy` is used in the `update` function on `client.mutate` to give you a window into your normalized data.
 
+This interface is currently only used in the context of the `update` function provided to [`ApolloClient.mutate`](apollo-client-api.html#ApolloClient.mutate).
+
 {% tsapibox DataProxy.readQuery %}
 {% tsapibox DataProxy.readFragment %}
 {% tsapibox DataProxy.writeQuery %}

--- a/source/data-control.md
+++ b/source/data-control.md
@@ -1,0 +1,252 @@
+---
+title: Data Control
+order: 109
+description: How to control your normalized data in the GraphQL store.
+---
+
+Apollo Client normalizes all of your data so that if any data you previously fetched from your GraphQL server is updated in a later data fetch from your server then your data will be updated with the latest truth from your server.
+
+This normalization process is constantly happening behind the scenes when you call `watchQuery` or use a view integration library like [`react-apollo`][], but this process is often not enough to describe the updates to your data model as the result of a mutation. For example, if you wanted to add an item to the end of an array fetched by one of your queries. You also might want to read data from the normalized Apollo Client store at a specific id without making another GraphQL server fetch.
+
+[`react-apollo`]: http://github.com/apollographql/react-apollo
+
+To interact directly with your data in the Apollo Client store you may use the methods `readQuery`, `readFragment`, `writeQuery`, and `writeFragment` that are accessible from the `ApolloClient` class. This article will teach you how to use these methods to control your data.
+
+If you would like a better understanding of the data normalization process then we recommend reading the [“How it works”][] documentation article. Knowledge around how Apollo Client works is not a prerequisite for using the methods described here, but it may be helpful.
+
+[“How it works”]: how-it-works.html
+
+All of the methods we will discuss can be called from the `ApolloClient` class. Any code demonstration in this article will assume that we have already initialized an instance of `ApolloClient` and assigned it to the `client`, and that we have imported the `gql` tag from `graphql-tag`. Like so:
+
+```js
+import { ApolloClient } from 'apollo-client';
+import { gql } from 'graphql-tag';
+
+const client = new ApolloClient({ ... });
+```
+
+<h2 id="readquery">`readQuery`</h2>
+
+The `readQuery` method is very similar to the `query` method except that `readQuery` will _never_ make a request to your GraphQL server. `query` will first see if there is enough data to fulfill the query in the cache. If there is then that data will be returned from the cache. If there is not enough data `query` will send a request to your [network interface][].
+
+[network interface]: network.html
+
+`readQuery`, on the other hand, will _always_ read from the cache. If there is not enough data in the cache then `readQuery` will throw an error instead of sending a network request. You can use `readQuery` by giving it a GraphQL query like so:
+
+```js
+const { todo } = client.readQuery({
+  query: gql`
+    query ReadTodo {
+      todo(id: 5) {
+        id
+        text
+        completed
+      }
+    }
+  `,
+});
+```
+
+If all of the data needed to fulfill this read is in Apollo Client’s normalized data cache then a data object will be returned in the shape of the query you wanted to read. If not all of the data needed to fulfill this read is in Apollo Client’s cache then an error will be thrown instead, so make sure to only read data that you know you have!
+
+You can also pass variables into `readQuery`.
+
+```js
+const { todo } = client.readQuery({
+  query: gql`
+    query ReadTodo($id: Int!) {
+      todo(id: $id) {
+        id
+        text
+        completed
+      }
+    }
+  `,
+  variables: {
+    id: 5,
+  },
+});
+```
+
+<h2 id="readfragment">`readFragment`</h2>
+
+This method allows you great flexibility around the data in your cache. Whereas `readQuery` only allowed you to read data from your root query type, `readFragment` allows you to read data from _any node you have queried_. This is incredibly powerful. You use this method as follows:
+
+```js
+const todo = client.readFragment({
+  id: ..., // `id` is any id that could be returned by `dataIdFromObject`.
+  fragment: gql`
+    fragment myTodo on Todo {
+      id
+      text
+      completed
+    }
+  `,
+});
+```
+
+The first argument is the id of the data you want to read from the cache. That id must be a value that was returned by the `dataIdFromObject` function you defined when initializing `ApolloClient`. So for example if you initialized `ApolloClient` like so:
+
+```js
+const client = new ApolloClient({
+  ...,
+  dataIdFromObject: object => object.id,
+});
+```
+
+…and you requested a todo before with an id of `5`, then you can read that todo out of your cache with the following:
+
+```js
+const todo = client.readFragment({
+  id: '5',
+  fragment: gql`
+    fragment myTodo on Todo {
+      id
+      text
+      completed
+    }
+  `,
+});
+```
+
+> **Note:** Most people add a `__typename` to the id in `dataIdFromObject`. If you do this then don’t forget to add the `__typename` when you are reading a fragment as well. So for example your id may be `Todo_5` and not just `5`.
+
+If a todo with that id does not exist in the cache you will get `null` back. If a todo of that id does exist in the cache, but that todo does not have the `text` field then an error will be thrown.
+
+The beauty of `readFragment` is that the todo could have come from anywhere! The todo could have been selected as a singleton (`{ todo(id: 5) { ... } }`), the todo could have come from a list of todos (`{ todos { ... } }`), or the todo could have come from a mutation (`mutation { createTodo { ... } }`). As long as at some point your GraphQL server gave you a todo with the provided id and fields `id`, `text`, and `completed` you can read it from the cache at any part of your code.
+
+<h2 id="writequery-and-writefragment">`writeQuery` and `writeFragment`</h2>
+
+Not only can you read arbitrary data from the Apollo Client cache, but you can also write any data that you would like to the cache. The methods you use to do this are `writeQuery` and `writeFragment`. They will allow you to change data in your local cache, but it is important to remember that *they will not change any data on your server*. If you reload your environment then changes made with `writeQuery` and `writeFragment` will disappear.
+
+These methods have the same signature as their `readQuery` and `readFragment` counterparts except they also require an additional `data` variable. So for example, if you wanted to update the `completed` flag locally for your todo with id `'5'` you could execute the following:
+
+```js
+client.writeFragment({
+  id: '5',
+  fragment: gql`
+    fragment myTodo on Todo {
+      completed
+    }
+  `,
+  data: {
+    completed: true,
+  },
+});
+```
+
+Any subscriber to the Apollo Client store will instantly see this update and render new UI accordingly.
+
+> **Note:** Again, remember that using `writeQuery` or `writeFragment` only changes data *locally*. If you reload your environment then changes made with these methods will no longer exist.
+
+Or if you wanted to add a new todo to a list fetched from the server, you could use `readQuery` and `writeQuery` together.
+
+```js
+const query = gql`
+  query MyTodoAppQuery {
+    todos {
+      id
+      text
+      completed
+    }
+  }
+`;
+
+const data = client.readQuery({ query });
+
+const myNewTodo = {
+  id: '6',
+  text: 'Start using Apollo Client.',
+  completed: false,
+};
+
+client.writeQuery({
+  query,
+  data: {
+    todos: [...data.todos, myNewTodo],
+  },
+});
+```
+
+<h2 id="updating-the-cache-after-a-mutation">Updating the cache after a mutation</h2>
+
+Being able to read and write to the Apollo cache from anywhere in your application gives you a lot of power over your data. However, there is one place where we most often want to update the data in our cache and so Apollo Client has optimized for that use case. That place would be after a mutation. Let us say that we have the following GraphQL mutation:
+
+```graphql
+mutation TodoCreateMutation($text: String!) {
+  createTodo(text: $text) {
+    id
+    text
+    completed
+  }
+}
+```
+
+We may also have the following GraphQL query:
+
+```graphql
+query TodoAppQuery {
+  todos {
+    id
+    text
+    completed
+  }
+}
+```
+
+At the end of our mutation we want our query to include the new todo like we had sent our `TodoAppQuery` a second time after the mutation finished without actually sending the query. To do this we can use the `update` function provided as an option of the `client.mutate` method. To update your cache with the mutation just write code that looks like:
+
+```js
+// We assume that the GraphQL operations `TodoCreateMutation` and
+// `TodoAppQuery` have already been defined using the `gql` tag.
+
+const text = 'Hello, world!';
+
+client.mutate({
+  mutation: TodoCreateMutation,
+  variables: {
+    text,
+  },
+  update: (proxy, { data: { createTodo } }) => {
+    // Read the data from our cache for this query.
+    const data = proxy.readQuery({ query: TodoAppQuery });
+
+    // Add our todo from the mutation to the end.
+    data.todos.push(createTodo);
+
+    // Write our data back to the cache.
+    proxy.writeQuery({ query: TodoAppQuery, data });
+  },
+});
+```
+
+The first `proxy` argument has the same for methods that we just learned exist on the Apollo Client: `readQuery`, `readFragment`, `writeQuery`, and `writeFragment`. The reason we call them on a `proxy` object here instead of on our `client` instance is that we can easily apply optimistic updates (which we will demonstrate in a bit). The `proxy` object also provides an isolated transaction which shields you from any other mutations going on at the same time, and the `proxy` object also batches writes together until the very end.
+
+The `update` function is not a good place for side-effects as it may be called multiple times, and you may not call any of the methods on `proxy` asynchronously.
+
+If you provide an `optimisticResponse` option to the mutation then the `update` function will be run twice. Once immeadiately after you call `client.mutate` with the data from `optimisticResponse`. After the mutation succesfully executes against the server the changes made in the first call to `update` will be rolled back and `update` will be called with the *actual* data returned by the mutation and not just the optimistic response.
+
+Putting it all together:
+
+```js
+const text = 'Hello, world!';
+
+client.mutate({
+  mutation: TodoCreateMutation,
+  variables: {
+    text,
+  },
+  optimisticResponse: {
+    id: -1, // -1 is a temporary id for the optimistic response.
+    text,
+    completed: false,
+  },
+  update: (proxy, { data: { createTodo } }) => {
+    const data = proxy.readQuery({ query: TodoAppQuery });
+    data.todos.push(createTodo);
+    proxy.writeQuery({ query: TodoAppQuery, data });
+  },
+});
+```
+
+As you can see the `update` function on `client.mutate` provides extra change management functionality specific to the use case of a mutation while still providing you the powerful data control APIs that are available on `client`.

--- a/source/data-control.md
+++ b/source/data-control.md
@@ -1,7 +1,7 @@
 ---
 title: Data Control
 order: 109
-description: How to control your normalized data in the GraphQL store.
+description: Powerful methods that give you total control over the data in your cache.
 ---
 
 Apollo Client normalizes all of your data so that if any data you previously fetched from your GraphQL server is updated in a later data fetch from your server then your data will be updated with the latest truth from your server.

--- a/source/data-control.md
+++ b/source/data-control.md
@@ -27,8 +27,9 @@ const client = new ApolloClient({ ... });
 
 <h2 id="readquery">`readQuery`</h2>
 
-The `readQuery` method is very similar to the `query` method except that `readQuery` will _never_ make a request to your GraphQL server. `query` will first see if there is enough data to fulfill the query in the cache. If there is then that data will be returned from the cache. If there is not enough data `query` will send a request to your [network interface][].
+The `readQuery` method is very similar to the [`query` method on `ApolloClient`][] except that `readQuery` will _never_ make a request to your GraphQL server. `query` will first see if there is enough data to fulfill the query in the cache. If there is then that data will be returned from the cache. If there is not enough data `query` will send a request to your [network interface][].
 
+[`query` method on `ApolloClient`]: apollo-client-api.html#ApolloClient.query
 [network interface]: network.html
 
 `readQuery`, on the other hand, will _always_ read from the cache. If there is not enough data in the cache then `readQuery` will throw an error instead of sending a network request. You can use `readQuery` by giving it a GraphQL query like so:
@@ -67,6 +68,12 @@ const { todo } = client.readQuery({
   },
 });
 ```
+
+**Resources:**
+
+- [`ApolloClient#query` API documentation](apollo-client-api.html#ApolloClient.query)
+- [`ApolloClient#readQuery` API documentation](apollo-client-api.html#ApolloClient.readQuery)
+- [`DataProxy#readQuery` API documentation](apollo-client-api.html#DataProxy.readQuery)
 
 <h2 id="readfragment">`readFragment`</h2>
 
@@ -114,6 +121,11 @@ const todo = client.readFragment({
 If a todo with that id does not exist in the cache you will get `null` back. If a todo of that id does exist in the cache, but that todo does not have the `text` field then an error will be thrown.
 
 The beauty of `readFragment` is that the todo could have come from anywhere! The todo could have been selected as a singleton (`{ todo(id: 5) { ... } }`), the todo could have come from a list of todos (`{ todos { ... } }`), or the todo could have come from a mutation (`mutation { createTodo { ... } }`). As long as at some point your GraphQL server gave you a todo with the provided id and fields `id`, `text`, and `completed` you can read it from the cache at any part of your code.
+
+**Resources:**
+
+- [`ApolloClient#readFragment` API documentation](apollo-client-api.html#ApolloClient.readFragment)
+- [`DataProxy#readFragment` API documentation](apollo-client-api.html#DataProxy.readFragment)
 
 <h2 id="writequery-and-writefragment">`writeQuery` and `writeFragment`</h2>
 
@@ -168,6 +180,14 @@ client.writeQuery({
 });
 ```
 
+**Resources:**
+
+- [`ApolloClient#watchQuery` API documentation](apollo-client-api.html#ApolloClient.watchQuery)
+- [`ApolloClient#writeQuery` API documentation](apollo-client-api.html#ApolloClient.writeQuery)
+- [`ApolloClient#writeFragment` API documentation](apollo-client-api.html#ApolloClient.writeFragment)
+- [`DataProxy#writeQuery` API documentation](apollo-client-api.html#ApolloClient.writeQuery)
+- [`DataProxy#writeFragment` API documentation](apollo-client-api.html#ApolloClient.writeFragment)
+
 <h2 id="updating-the-cache-after-a-mutation">Updating the cache after a mutation</h2>
 
 Being able to read and write to the Apollo cache from anywhere in your application gives you a lot of power over your data. However, there is one place where we most often want to update the data in our cache and so Apollo Client has optimized for that use case. That place would be after a mutation. Let us say that we have the following GraphQL mutation:
@@ -220,7 +240,9 @@ client.mutate({
 });
 ```
 
-The first `proxy` argument has the same for methods that we just learned exist on the Apollo Client: `readQuery`, `readFragment`, `writeQuery`, and `writeFragment`. The reason we call them on a `proxy` object here instead of on our `client` instance is that we can easily apply optimistic updates (which we will demonstrate in a bit). The `proxy` object also provides an isolated transaction which shields you from any other mutations going on at the same time, and the `proxy` object also batches writes together until the very end.
+The first `proxy` argument is an instance of [`DataProxy`][] has the same for methods that we just learned exist on the Apollo Client: `readQuery`, `readFragment`, `writeQuery`, and `writeFragment`. The reason we call them on a `proxy` object here instead of on our `client` instance is that we can easily apply optimistic updates (which we will demonstrate in a bit). The `proxy` object also provides an isolated transaction which shields you from any other mutations going on at the same time, and the `proxy` object also batches writes together until the very end.
+
+[`DataProxy`](apollo-client-api.html#DataProxy)
 
 The `update` function is not a good place for side-effects as it may be called multiple times, and you may not call any of the methods on `proxy` asynchronously.
 
@@ -250,3 +272,8 @@ client.mutate({
 ```
 
 As you can see the `update` function on `client.mutate` provides extra change management functionality specific to the use case of a mutation while still providing you the powerful data control APIs that are available on `client`.
+
+**Resources:**
+
+- [`ApolloClient#mutate` API documentation](apollo-client-api.html#ApolloClient.mutate)
+- [`DataProxy` API documentation](apollo-client-api.html#DataProxy)

--- a/source/read-and-write.md
+++ b/source/read-and-write.md
@@ -1,5 +1,5 @@
 ---
-title: Data Control
+title: Reading and Writing to the Store
 order: 109
 description: Powerful methods that give you total control over the data in your cache.
 ---

--- a/source/read-and-write.md
+++ b/source/read-and-write.md
@@ -1,7 +1,7 @@
 ---
-title: Reading and Writing to the Store
+title: Direct Cache Access
 order: 109
-description: Powerful methods that give you total control over the data in your cache.
+description: Read and write functions for fine-grained cache access.
 ---
 
 Apollo Client normalizes all of your data so that if any data you previously fetched from your GraphQL server is updated in a later data fetch from your server then your data will be updated with the latest truth from your server.
@@ -27,12 +27,9 @@ const client = new ApolloClient({ ... });
 
 <h2 id="readquery">`readQuery`</h2>
 
-The `readQuery` method is very similar to the [`query` method on `ApolloClient`][] except that `readQuery` will _never_ make a request to your GraphQL server. `query` will first see if there is enough data to fulfill the query in the cache. If there is then that data will be returned from the cache. If there is not enough data `query` will send a request to your [network interface][].
+The `readQuery` method is very similar to the [`query` method on `ApolloClient`][] except that `readQuery` will _never_ make a request to your GraphQL server. The `query` method, on the other hand, may send a request to your server if the appropriate data is not in your cache whereas `readQuery` will throw an error if the data is not in your cache. `readQuery` will _always_ read from the cache. You can use `readQuery` by giving it a GraphQL query like so:
 
 [`query` method on `ApolloClient`]: apollo-client-api.html#ApolloClient.query
-[network interface]: network.html
-
-`readQuery`, on the other hand, will _always_ read from the cache. If there is not enough data in the cache then `readQuery` will throw an error instead of sending a network request. You can use `readQuery` by giving it a GraphQL query like so:
 
 ```js
 const { todo } = client.readQuery({
@@ -190,7 +187,7 @@ client.writeQuery({
 
 <h2 id="updating-the-cache-after-a-mutation">Updating the cache after a mutation</h2>
 
-Being able to read and write to the Apollo cache from anywhere in your application gives you a lot of power over your data. However, there is one place where we most often want to update the data in our cache and so Apollo Client has optimized for that use case. That place would be after a mutation. Let us say that we have the following GraphQL mutation:
+Being able to read and write to the Apollo cache from anywhere in your application gives you a lot of power over your data. However, there is one place where we most often want to update our cached data: after a mutation. As such, Apollo Client has optimized the experience for updating your cache with the read and write methods after a mutation with the `update` function. Let us say that we have the following GraphQL mutation:
 
 ```graphql
 mutation TodoCreateMutation($text: String!) {
@@ -244,8 +241,6 @@ The first `proxy` argument is an instance of [`DataProxy`][] has the same for me
 
 [`DataProxy`](apollo-client-api.html#DataProxy)
 
-The `update` function is not a good place for side-effects as it may be called multiple times, and you may not call any of the methods on `proxy` asynchronously.
-
 If you provide an `optimisticResponse` option to the mutation then the `update` function will be run twice. Once immeadiately after you call `client.mutate` with the data from `optimisticResponse`. After the mutation succesfully executes against the server the changes made in the first call to `update` will be rolled back and `update` will be called with the *actual* data returned by the mutation and not just the optimistic response.
 
 Putting it all together:
@@ -272,6 +267,8 @@ client.mutate({
 ```
 
 As you can see the `update` function on `client.mutate` provides extra change management functionality specific to the use case of a mutation while still providing you the powerful data control APIs that are available on `client`.
+
+The `update` function is not a good place for side-effects as it may be called multiple times. Also, you may not call any of the methods on `proxy` asynchronously.
 
 **Resources:**
 


### PR DESCRIPTION
This PR adds docs for the new read and write methods added in https://github.com/apollographql/apollo-client/pull/1310

There is some work that needs to be done to get the API documentation looking good. I’m almost done with that, I am just hitting a problem with `typedoc` rendering of generic return types where `readQuery<T>(options: DataProxyReadQueryOptions): T` and `readFragment<T>(options: DataProxyReadFragmentOptions): T | null` renders to:

![screen shot 2017-03-02 at 2 33 44 pm](https://cloud.githubusercontent.com/assets/8282507/23523518/431ddb90-ff55-11e6-8b0c-45b259ad2119.png)

If you have a fix for this, let me know. Otherwise, I’ll update this thread when I’ve found a solution.

cc @stubailo, @helfer