### PR TITLE
Add docs for the exposure of 'dataIdFromObject' and 'dataId'

### DIFF
--- a/source/apollo-client-api.md
+++ b/source/apollo-client-api.md
@@ -17,6 +17,8 @@ The `ApolloClient` class is the core API for Apollo, and the one you'll need to 
 {% tsapibox ApolloClient.writeQuery %}
 {% tsapibox ApolloClient.writeFragment %}
 {% tsapibox ApolloClient.reducer %}
+{% tsapibox ApolloClient.dataId %}
+{% tsapibox ApolloClient.dataIdFromObject %}
 {% tsapibox ApolloClient.middleware %}
 {% tsapibox ApolloClient.initStore %}
 {% tsapibox ApolloClient.setStore %}


### PR DESCRIPTION
As discussed in [apollographql/apollo-client#1657 (comment)](https://github.com/apollographql/apollo-client/issues/1657#issuecomment-299536799)

Merge after apollographql/react-docs#221

CC: @helfer