### PR TITLE
[WIP] circle.yml: do not cache site/node_modules, move to yarn

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,8 +7,6 @@ checkout:
     - git submodule update --init
 
 dependencies:
-  cache_directories:
-    - "site/node_modules"
   override:
     - npm install -g hexo-cli
     - npm install

--- a/circle.yml
+++ b/circle.yml
@@ -1,15 +1,13 @@
-machine:
-  node:
-    version: 4
-
 checkout:
   post:
     - git submodule update --init
 
 dependencies:
+  cache_directories:
+    - ~/.cache/yarn
   override:
-    - npm install -g hexo-cli
-    - npm install
+    - yarn add hexo-cli
+    - yarn
 
 test:
   override:
@@ -20,4 +18,4 @@ deployment:
   s3:
     branch: /^(master|version-.*)/
     commands:
-      - npm run deploy
+      - yarn run deploy


### PR DESCRIPTION
sites/node_modules doesn't exist anyway, according to Circle itself, eg:

    circle.yml specified cache directory: /home/ubuntu/core-docs/site/node_modules but it does not exist
@ https://circleci.com/gh/apollographql/core-docs/586

Yarn is, on the other hand, is cacheable without much of any risk, so the second commit moves to Yarn.