### PR TITLE
adding a super simple client/server example

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -28,6 +28,7 @@ We have put together some basic example apps using various parts of Apollo; chec
 - [A production-ready starter-kit using React and Webpack](https://github.com/saikat/react-apollo-starter-kit)
 - [Apollo Universal Starter Kit with Hot Code Reload for backend & frontend, uses React, Webpack, Babel and SQL](https://github.com/sysgears/apollo-fullstack-starter-kit)
 - [Apollo Client example that uses Github GraphQL API with create-react-app](https://github.com/katopz/react-apollo-graphql-github-example)
+- [vanilla Apollo client and server. Just the bare-bones, no database or UI](https://github.com/farskipper/vanilla-js-apollo-graphql-full-stack-playground)
 
 ### Meteor Examples
 - [A bare-bones Meteor starter kit](https://github.com/apollostack/meteor-starter-kit)


### PR DESCRIPTION
This repo is just a simple playground for GraphQL n00bs like me. It's only `client.js` and `server.js` both under 50 lines.

Having a minimalist sandbox like this helped me wrap my mind around Apollo, before I started adding all the ceremony that comes along with a UI and database.

Thanks!