### PR TITLE
Fix outdated queryDeduplication docs

### DIFF
--- a/source/network.md
+++ b/source/network.md
@@ -404,14 +404,7 @@ Query batching is a transport-level mechanism that works only with servers that 
  ```
 
  <h2 id="query-deduplication">Query deduplication</h2>
- Query deduplication can help reduce the number of queries that are sent over the wire. It is turned off by default, but can be turned on by passing the `queryDeduplication` option to Apollo Client. If turned on, query deduplication happens before the query hits the network layer.
-
-```js
-const apolloClient = new ApolloClient({
-  networkInterface: batchingNetworkInterface,
-  queryDeduplication: true,
-});
- ```
+ Query deduplication can help reduce the number of queries that are sent over the wire. It is turned on by default, but can be turned off by passing `queryDeduplication: false` to the Apollo Client constructor. If turned on, query deduplication happens before the query hits the network layer.
 
  Query deduplication can be useful if many components display the same data, but you don't want to fetch that data from the server many times. It works by comparing a query to all queries currently in flight. If an identical query is currently in flight, the new query will be mapped to the same promise and resolved when the currently in-flight query returns.
 


### PR DESCRIPTION
I noticed that the default for `queryDeduplication` has changed to true recently ([see source](https://github.com/apollographql/apollo-client/blob/25e38f5782128a07256e3e1878422403b1b6138c/src/ApolloClient.ts#L199)) but the docs were outdated.

I've also seen that [the `queryDeduplication` option of `QueryManager` defaults to false](https://github.com/apollographql/apollo-client/blob/13ecb9a280f763c02e384743eedff9acb02218b4/src/core/QueryManager.ts#L164), but is overridden by the default from `ApolloClient`. Is that class used independently of `ApolloClient`? If not, maybe it's a good idea to remove that default there.

---

On a different note: I was wondering if partial query deduplication could also be a thing? Consider the following query:

```
query Book($bookId: ID!) {
  book(id: $bookId) {
    title
  }
  me {
    name
  }
}
```

Here the variable is only applied to the `book` field on `Query`, however the `me` field is static. Could this part of the query be deduplicated? I ran into this just now, where the static part of the query is pretty big. I split the query into two then, but it would of course be nice if this would work out of the box. Thoughts?