### PR TITLE
Fix link formatting

### DIFF
--- a/source/read-and-write.md
+++ b/source/read-and-write.md
@@ -239,7 +239,7 @@ client.mutate({
 
 The first `proxy` argument is an instance of [`DataProxy`][] has the same for methods that we just learned exist on the Apollo Client: `readQuery`, `readFragment`, `writeQuery`, and `writeFragment`. The reason we call them on a `proxy` object here instead of on our `client` instance is that we can easily apply optimistic updates (which we will demonstrate in a bit). The `proxy` object also provides an isolated transaction which shields you from any other mutations going on at the same time, and the `proxy` object also batches writes together until the very end.
 
-[`DataProxy`](apollo-client-api.html#DataProxy)
+[`DataProxy`]: apollo-client-api.html#DataProxy
 
 If you provide an `optimisticResponse` option to the mutation then the `update` function will be run twice. Once immediately after you call `client.mutate` with the data from `optimisticResponse`. After the mutation successfully executes against the server the changes made in the first call to `update` will be rolled back and `update` will be called with the *actual* data returned by the mutation and not just the optimistic response.
 


### PR DESCRIPTION
Noticed this in the docs:

![image](https://user-images.githubusercontent.com/595711/30031083-f3e39f06-9144-11e7-9734-4de88c21e3ee.png)

:point_up: Notice the extra `[]`.

So I updated to what I think is the correct formatting based on other links in the docs.